### PR TITLE
fix: Adapt to Qt6 being now the default

### DIFF
--- a/kdchart-qt5.rb
+++ b/kdchart-qt5.rb
@@ -11,7 +11,7 @@ class KdchartQt5 < Formula
 
 
   def install
-    system "cmake", ".", "-G", "Ninja", *std_cmake_args
+    system "cmake", ".", "-G", "Ninja", "-DKDChart_QT6=OFF", *std_cmake_args
     system "ninja"
     system "ninja", "install"
   end

--- a/kddockwidgets-qt5.rb
+++ b/kddockwidgets-qt5.rb
@@ -11,7 +11,7 @@ class KddockwidgetsQt5 < Formula
 
 
   def install
-    system "cmake", ".", "-G", "Ninja", "-DKDDockWidgets_NO_SPDLOG=ON", *std_cmake_args
+    system "cmake", ".", "-G", "Ninja", "-DKDDockWidgets_NO_SPDLOG=ON", "-DKDDockWidgets_QT6=OFF", *std_cmake_args
     system "ninja"
     system "ninja", "install"
   end

--- a/kdreports-qt5.rb
+++ b/kdreports-qt5.rb
@@ -11,7 +11,7 @@ class KdreportsQt5 < Formula
 
 
   def install
-    system "cmake", ".", "-G", "Ninja", *std_cmake_args
+    system "cmake", ".", "-G", "Ninja", "-DKDReports_QT6=OFF", *std_cmake_args
     system "ninja"
     system "ninja", "install"
   end

--- a/kdsingleapplication-qt5.rb
+++ b/kdsingleapplication-qt5.rb
@@ -11,7 +11,7 @@ class KdsingleapplicationQt5 < Formula
 
 
   def install
-    system "cmake", ".", "-G", "Ninja", *std_cmake_args
+    system "cmake", ".", "-G", "Ninja", "-DKDSingleApplication_QT6=OFF", *std_cmake_args
     system "ninja"
     system "ninja", "install"
   end

--- a/kdsoap-qt5.rb
+++ b/kdsoap-qt5.rb
@@ -11,7 +11,7 @@ class KdsoapQt5 < Formula
 
 
   def install
-    system "cmake", ".", "-G", "Ninja", *std_cmake_args
+    system "cmake", ".", "-G", "Ninja", "-DKDSoap_QT6=OFF", *std_cmake_args
     system "ninja"
     system "ninja", "install"
   end

--- a/kdstatemachineeditor-qt5.rb
+++ b/kdstatemachineeditor-qt5.rb
@@ -16,7 +16,7 @@ class KdstatemachineeditorQt5 < Formula
     bison_bin = "#{HOMEBREW_PREFIX}/opt/bison/bin"
     ENV["PATH"] = "#{bison_bin}:#{ENV["PATH"]}"
 
-    system "cmake", "-G", "Ninja", "-DKDSME_INTERNAL_GRAPHVIZ=OFF", ".", *std_cmake_args
+    system "cmake", "-G", "Ninja", "-DBUILD_QT6=OFF", "-DKDSME_INTERNAL_GRAPHVIZ=OFF", ".", *std_cmake_args
     system "ninja"
     system "ninja", "install"
   end


### PR DESCRIPTION
Explicitly disable Qt6 in the Qt5 recipes